### PR TITLE
Fixing error color and title color

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -70,7 +70,8 @@ export default class TextField extends PureComponent {
     tintColor: PropTypes.string,
     textColor: PropTypes.string,
     baseColor: PropTypes.string,
-
+    titleColor: PropTypes.string,
+    
     label: PropTypes.string.isRequired,
     title: PropTypes.string,
 
@@ -348,6 +349,7 @@ export default class TextField extends PureComponent {
       labelColor,
       textColor,
       errorColor,
+      titleColor,
       lineWidth,
       activeLineWidth,
       containerStyle,
@@ -439,7 +441,7 @@ export default class TextField extends PureComponent {
     };
 
     let titleStyle = {
-      color: baseColor,
+      color: titleColor || baseColor,
 
       opacity: focus.interpolate({
         inputRange: [-1, 0, 1],
@@ -541,8 +543,8 @@ export default class TextField extends PureComponent {
 
         <Animated.View style={helperContainerStyle}>
           <View style={styles.flex}>
-            <Helper style={[errorStyle, titleTextStyle]}>{error}</Helper>
-            <Helper style={[titleStyle, titleTextStyle]}>{title}</Helper>
+            <Helper style={errorStyle}>{error}</Helper>
+            <Helper style={titleStyle}>{title}</Helper>
           </View>
 
           <Counter {...counterProps} />


### PR DESCRIPTION
- Adding titleColor prop
- avoid override from titleTextStyle in the error helper
![image](https://user-images.githubusercontent.com/1137100/42119088-72087d6c-7bbd-11e8-8896-24ea85b82e71.png)
